### PR TITLE
feat(extension): add MV3 scaffold with content script

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,0 +1,1 @@
+console.log("Slack Thread Copier loaded");

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "Slack Thread Copier",
+  "version": "0.1.0",
+  "content_scripts": [
+    {
+      "matches": ["https://app.slack.com/*"],
+      "js": ["content.js"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `manifest.json` (Manifest V3, content script scoped to app.slack.com)
- Add `content.js` with single `console.log("Slack Thread Copier loaded")`

## Test plan
- [x] Load unpacked via `chrome://extensions` → no errors
- [x] Navigate to `app.slack.com` → verify "Slack Thread Copier loaded" in console

resolves #2