### PR TITLE
feat(extractor): add message extractor + MutationObserver wiring

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,1 +1,23 @@
 console.log("Slack Thread Copier loaded");
+
+function onThreadOpen(threadPanelNode) {
+  const messages = extractMessages(threadPanelNode);
+  console.log("[Slack Thread Copier] Extracted messages:", messages);
+}
+
+const observer = new MutationObserver((mutations) => {
+  for (const mutation of mutations) {
+    for (const node of mutation.addedNodes) {
+      if (node.nodeType !== Node.ELEMENT_NODE) continue;
+      const panel = node.matches('[data-qa="threads_flexpane"]')
+        ? node
+        : node.querySelector('[data-qa="threads_flexpane"]');
+      if (panel) {
+        onThreadOpen(panel);
+        return;
+      }
+    }
+  }
+});
+
+observer.observe(document.body, { childList: true, subtree: true });

--- a/extractor.js
+++ b/extractor.js
@@ -1,0 +1,28 @@
+function extractMessages(threadPanelNode) {
+  const items = threadPanelNode.querySelectorAll('[data-qa="virtual-list-item"]');
+  const messages = [];
+  let lastAuthor = "";
+
+  for (const item of items) {
+    const container = item.querySelector('[data-qa="message_container"]');
+    if (!container) continue;
+
+    const senderEl = container.querySelector('[data-qa="message_sender_name"]');
+    const author = senderEl ? senderEl.textContent.trim() : lastAuthor;
+    if (senderEl) lastAuthor = author;
+
+    const timestampEl = container.querySelector('[data-qa="timestamp_label"]');
+    const timestamp = timestampEl ? timestampEl.textContent.trim() : "";
+
+    const textEl = container.querySelector('[data-qa="message-text"]');
+    const content = textEl ? textEl.textContent.trim() : "";
+
+    messages.push({ author, timestamp, content });
+  }
+
+  return messages;
+}
+
+if (typeof module !== "undefined") {
+  module.exports = { extractMessages };
+}

--- a/formatter.js
+++ b/formatter.js
@@ -1,6 +1,6 @@
 function format(messages) {
   return messages
-    .map(({ username, timestamp, content }) => `**@${username}** (${timestamp}):\n${content}`)
+    .map(({ author, timestamp, content }) => `**@${author}** (${timestamp}):\n${content}`)
     .join("\n\n");
 }
 

--- a/formatter.test.js
+++ b/formatter.test.js
@@ -3,20 +3,20 @@ const assert = require("node:assert/strict");
 const { format } = require("./formatter");
 
 test("single message", () => {
-  const result = format([{ username: "alice", timestamp: "10:00 AM", content: "Hello" }]);
+  const result = format([{ author: "alice", timestamp: "10:00 AM", content: "Hello" }]);
   assert.equal(result, "**@alice** (10:00 AM):\nHello");
 });
 
 test("multiple messages separated by blank line", () => {
   const result = format([
-    { username: "alice", timestamp: "10:00 AM", content: "Hello" },
-    { username: "bob", timestamp: "10:01 AM", content: "Hi" },
+    { author: "alice", timestamp: "10:00 AM", content: "Hello" },
+    { author: "bob", timestamp: "10:01 AM", content: "Hi" },
   ]);
   assert.equal(result, "**@alice** (10:00 AM):\nHello\n\n**@bob** (10:01 AM):\nHi");
 });
 
 test("empty content", () => {
-  const result = format([{ username: "alice", timestamp: "10:00 AM", content: "" }]);
+  const result = format([{ author: "alice", timestamp: "10:00 AM", content: "" }]);
   assert.equal(result, "**@alice** (10:00 AM):\n");
 });
 
@@ -25,6 +25,6 @@ test("empty array", () => {
 });
 
 test("special characters", () => {
-  const result = format([{ username: "alice", timestamp: "10:00 AM", content: "<script>alert('xss')</script> & \"quotes\"" }]);
+  const result = format([{ author: "alice", timestamp: "10:00 AM", content: "<script>alert('xss')</script> & \"quotes\"" }]);
   assert.equal(result, "**@alice** (10:00 AM):\n<script>alert('xss')</script> & \"quotes\"");
 });

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "content_scripts": [
     {
       "matches": ["https://app.slack.com/*"],
-      "js": ["content.js"]
+      "js": ["extractor.js", "content.js"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `extractor.js` with `extractMessages(threadPanelNode)` using verified Slack DOM selectors (`[data-qa="message_container"]`, `[data-qa="message_sender_name"]`, `[data-qa="timestamp_label"]`, `[data-qa="message-text"]`)
- Track last author for compact/consecutive messages where sender is hidden
- Wire into `content.js` via `MutationObserver` — logs extracted messages to console on thread open
- Rename `username` → `author` in `formatter.js` and tests

## Test plan
- [x] Load extension on `app.slack.com`
- [x] Open a thread panel
- [x] Check DevTools console for `[Slack Thread Copier] Extracted messages:` log
- [x] Verify message objects have correct `author`, `timestamp`, `content`
- [x] Verify compact messages (consecutive, no sender shown) inherit correct author
- [x] Run `node --test formatter.test.js` — all 5 tests pass

resolves #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)